### PR TITLE
Add simple realtime satoshi price page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # 1sat1CLP
-Pagina que muestra la cotizacion en tiempo real de 1 satoshi en pesos chilenos
+
+Una p\u00e1gina sencilla que muestra en tiempo real el valor de 1 satoshi en pesos chilenos.
+
+El dato se obtiene desde la API de [yadio.io](https://api.yadio.io/exrates/btc) y se actualiza autom\u00e1ticamente cada 30 segundos.
+
+## Uso
+
+Solo abre `index.html` en tu navegador favorito. Se mostrar\u00e1 el valor expresado en CLP y la hora de la \u00faltima actualizaci\u00f3n.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>1 sat = CLP</title>
+<style>
+  body {
+    background:#111;
+    color:#0f0;
+    font-family: monospace;
+    display:flex;
+    flex-direction:column;
+    justify-content:center;
+    align-items:center;
+    height:100vh;
+    margin:0;
+  }
+  #value {
+    font-size:4em;
+  }
+  #timestamp {
+    margin-top:1em;
+    font-size:1em;
+    color:#888;
+  }
+</style>
+</head>
+<body>
+<div id="value">Cargando...</div>
+<div id="timestamp"></div>
+<script>
+async function fetchSat(){
+  try {
+    const res = await fetch('https://api.yadio.io/exrates/btc');
+    const data = await res.json();
+    const priceCLP = data.BTC.CLP;
+    const sat = priceCLP / 100000000;
+    document.getElementById('value').textContent = sat.toLocaleString('es-CL',{style:'currency',currency:'CLP'});
+    document.getElementById('timestamp').textContent = new Date().toLocaleTimeString('es-CL');
+  } catch(e){
+    document.getElementById('value').textContent = 'Error';
+  }
+}
+fetchSat();
+setInterval(fetchSat, 30000);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` with JS that fetches 1 satoshi price in CLP
- update README with usage instructions

## Testing
- `w3m -dump index.html | head`

------
https://chatgpt.com/codex/tasks/task_e_6860c8ee3c04832ea5bf5c560ad93c5f