### PR TITLE
Add open-source link and bitcoin vs peso illustration

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,10 @@
     margin-bottom:2em;
     text-align:center;
   }
+  #illustration {
+    margin-bottom:1em;
+    width:200px;
+  }
   #value {
     font-size:4em;
   }
@@ -45,9 +49,10 @@
 <body>
 <h1 id="hero"><a href="https://achicrip.org" target="_blank">Asociación Chilena de Criptotecnologías</a></h1>
 <p id="desc">Esta página muestra el valor de 1 satoshi en pesos chilenos, actualizado cada 30 segundos.</p>
+<img id="illustration" src="img/bitcoin_aplasta_peso.png" alt="Bitcoin aplastando a un peso chileno" />
 <div id="value">Cargando...</div>
 <div id="timestamp"></div>
-<footer id="footer">© 2025 goro2030 para Achicrip</footer>
+<footer id="footer">© 2025 goro2030 para Achicrip. Este software es <a href="https://github.com/goro2030/1sat1CLP" target="_blank">open source en GitHub</a>.</footer>
 <script>
 async function fetchSat(){
   try {


### PR DESCRIPTION
## Summary
- Link to GitHub repo in footer stating project is open source
- Reference illustration of a bitcoin crushing a Chilean peso, to be added manually

## Testing
- `tidy -q -e index.html`


------
https://chatgpt.com/codex/tasks/task_e_689fe18f3c70832eb3ff729bd849ceda